### PR TITLE
Smallcache

### DIFF
--- a/box/run.go
+++ b/box/run.go
@@ -6,7 +6,7 @@ import (
 )
 
 // MaxBytes is the largest capacity of bytes in a box
-var MaxBytes = 512 + 3
+var MaxBytes = 256 + 3
 
 func NewRun(minDx, maxDx int, ft *font.Font, newRulerFunc ...func([]byte, *font.Font) Ruler) Run {
 	fn := NewByteRuler
@@ -20,7 +20,6 @@ func NewRun(minDx, maxDx int, ft *font.Font, newRulerFunc ...func([]byte, *font.
 		Font:         ft,
 		newRulerFunc: fn,
 		br:           fn(make([]byte, MaxBytes), ft),
-		br2:          fn(make([]byte, MaxBytes), ft),
 	}
 }
 
@@ -39,7 +38,6 @@ type Run struct {
 
 	newRulerFunc func([]byte, *font.Font) Ruler
 	br           Ruler
-	br2          Ruler
 }
 
 func (f *Run) Combine(g *Run, n int) {
@@ -118,14 +116,14 @@ func (f *Run) Split(bn, n int) {
 }
 
 func (f *Run) MeasureBytes(p []byte) int {
-	br := f.newRulerFunc(p, f.Font)
+	f.br.Reset(p)//f.newRulerFunc(p, f.Font)
 	for {
-		_, _, err := br.Next()
+		_, _, err := f.br.Next()
 		if err != nil {
 			break
 		}
 	}
-	return br.Width()
+	return f.br.Width()
 }
 
 // Chop drops the first n chars in box b

--- a/draw.go
+++ b/draw.go
@@ -133,6 +133,13 @@ func (f *Frame) drawsel(pt image.Point, p0, p1 int64, back, text image.Image) im
 			if f.PlainBox(nb) {
 				f.stringNBG(f.b, pt, text, image.ZP, f.Font, ptr)
 			}
+// TODO(as): replace the above with the snippet below: reason:
+// stringBG is more efficient now that it does an src bitblt for an already-known character
+//			if f.PlainBox(nb){
+//				f.stringBG(f.b, pt, text, image.ZP, f.Font, ptr)
+//			} else {
+//				f.Draw(f.b, image.Rect(pt.X, pt.Y, min(pt.X+w, f.r.Max.X), pt.Y+f.Font.Dy()), back, pt, f.op)
+//			}
 			pt.X += w
 
 			if q0 += len(ptr); q0 >= p1 {

--- a/font/decon.go
+++ b/font/decon.go
@@ -26,9 +26,9 @@ func deconvolve(m *image.Alpha) *image.Alpha {
 		for x := 0; x < m.Bounds().Dx(); x++ {
 			a := m.AlphaAt(x, y)
 			mean := int(
-				av(x-1, y-1) + av(x, y-1) + av(x+1, y-1)+
-				av(x-1, y-0) + av(x, y-0) + av(x+1, y-0)+
-				av(x-1, y+1) + av(x, y+1) + av(x+1, y+1)) / 8
+				av(x-1, y-1)+av(x, y-1)+av(x+1, y-1)+
+					av(x-1, y-0)+av(x, y-0)+av(x+1, y-0)+
+					av(x-1, y+1)+av(x, y+1)+av(x+1, y+1)) / 8
 			if a.A-uint8(mean) > a.A {
 				a.A = 0
 			} else {

--- a/font/decon.go
+++ b/font/decon.go
@@ -1,0 +1,59 @@
+package font
+
+import "image"
+
+func deconvolveGlyph(g *Glyph) *Glyph {
+	if g.mask == nil {
+		panic("deconvolveGlyph: nil g.mask")
+	}
+	g.mask = deconvolve(g.mask)
+	return g
+}
+
+func ampGlyph(g *Glyph) *Glyph {
+	if g.mask == nil {
+		panic("ampGlyph: nil g.mask")
+	}
+	g.mask = amp(g.mask)
+	return g
+}
+func deconvolve(m *image.Alpha) *image.Alpha {
+	av := func(x, y int) uint8 {
+		a := m.AlphaAt(x, y)
+		return a.A
+	}
+	for y := 0; y < m.Bounds().Dy(); y++ {
+		for x := 0; x < m.Bounds().Dx(); x++ {
+			a := m.AlphaAt(x, y)
+			mean := int(
+				av(x-1, y-1) + av(x, y-1) + av(x+1, y-1)+
+				av(x-1, y-0) + av(x, y-0) + av(x+1, y-0)+
+				av(x-1, y+1) + av(x, y+1) + av(x+1, y+1)) / 8
+			if a.A-uint8(mean) > a.A {
+				a.A = 0
+			} else {
+				a.A -= uint8(mean)
+			}
+			defer m.SetAlpha(x, y, a)
+		}
+	}
+	return m
+}
+
+func amp(m *image.Alpha) *image.Alpha {
+	for y := 0; y < m.Bounds().Dy(); y++ {
+		for x := 0; x < m.Bounds().Dx(); x++ {
+			a := m.AlphaAt(x, y)
+			if a.A < 64 {
+				continue
+			}
+			if a.A+64 < a.A {
+				a.A = 255
+			} else {
+				a.A += 64
+			}
+			defer m.SetAlpha(x, y, a)
+		}
+	}
+	return m
+}

--- a/font/draw.go
+++ b/font/draw.go
@@ -7,35 +7,23 @@ import (
 	"unicode/utf8"
 )
 
-type rgba struct{
-	r,g,b,a uint32
-}
-type signature struct{
-	b byte
-	dy int
-	rgba
-}
-var cache map[signature]*image.RGBA
-func init(){
-	cache = make(map[signature]*image.RGBA)
-}
-
 func StringBG(dst draw.Image, p image.Point, src image.Image, sp image.Point, ft *Font, s []byte, bg image.Image, bgp image.Point) int {
+	cache := ft.imgCache
 	quad := rgba{}
 	{
-		r,g,b,a := src.(*image.Uniform).RGBA()
-		quad=rgba{r,g,b,a}
+		r, g, b, a := bg.(*image.Uniform).RGBA()
+		quad = rgba{r, g, b, a}
 	}
 	sig := signature{
-		dy: ft.Dy(),
+		dy:   ft.Dy(),
 		rgba: quad,
 	}
 	r0 := image.Rectangle{p, p}
 	for _, b := range s {
 		sig.b = b
-		if img, ok := cache[sig]; ok{
+		if img, ok := cache[sig]; ok {
 			draw.Draw(dst, img.Bounds().Add(p), img, img.Bounds().Min, draw.Src)
-			p.X+=img.Bounds().Dx()+ft.stride //Add(image.Pt(img.Bounds().Dx(), 0))
+			p.X += img.Bounds().Dx() + ft.stride //Add(image.Pt(img.Bounds().Dx(), 0))
 			continue
 		}
 		mask := ft.Char(b)
@@ -43,19 +31,19 @@ func StringBG(dst draw.Image, p image.Point, src image.Image, sp image.Point, ft
 			panic("StringBG")
 		}
 		r := mask.Bounds()
-		if r0.Min == image.ZP{
+		if r0.Min == image.ZP {
 			r0.Min = r.Add(p).Min
 		}
 		draw.DrawMask(dst, r.Add(p), src, sp, mask, mask.Bounds().Min, draw.Over)
 		img := image.NewRGBA(r)
 		draw.Draw(img, img.Bounds(), bg, bgp, draw.Src)
 		draw.Draw(img, img.Bounds(), dst, r.Add(p).Min, draw.Src)
-		cache[sig]=img
-		
+		cache[sig] = img
+
 		p.X += r.Dx() + ft.stride
 		r0.Max.X += r.Dx() + ft.stride
-		if r.Dy() > r0.Dy(){
-			r0.Max.Y=r.Dy()
+		if r.Dy() > r0.Dy() {
+			r0.Max.Y = r.Dy()
 		}
 	}
 	return p.X

--- a/font/font.go
+++ b/font/font.go
@@ -62,12 +62,13 @@ func NewBasic(size int) *Font {
 	f := basicfont.Face7x13
 	size = 13
 	ft := &Font{
-		Face:    f,
-		size:    size,
-		ascent:  2,
-		descent: 1,
-		letting: 0,
-		stride:  0,
+		Face:     f,
+		size:     size,
+		ascent:   2,
+		descent:  1,
+		letting:  0,
+		stride:   0,
+		imgCache: make(map[signature]*image.RGBA),
 	}
 	ft.dy = ft.ascent + ft.descent + ft.size
 	hexFt := fromTTF(gomono.TTF, ft.Dy()/4+3)
@@ -118,11 +119,11 @@ func fromTTF(data []byte, size int) *Font {
 			&truetype.Options{
 				Size: float64(size),
 			}),
-		size:    size,
-		ascent:  2,
-		descent: +(size / 3),
-		stride:  0,
-		data:    data,
+		size:     size,
+		ascent:   2,
+		descent:  +(size / 3),
+		stride:   0,
+		data:     data,
 		imgCache: make(map[signature]*image.RGBA),
 	}
 	ft.dy = ft.ascent + ft.descent + ft.size

--- a/font/srv.go
+++ b/font/srv.go
@@ -1,0 +1,74 @@
+package font
+
+import (
+	"hash/crc32"
+	"image"
+
+	"github.com/golang/freetype/truetype"
+)
+
+var fontIRQ chan fontPKT
+
+type fontPKT struct {
+	id    string
+	data  []byte
+	reply chan interface{}
+}
+
+func fontsrv() {
+	parsedTTF := make(map[string]*truetype.Font)
+	for {
+		select {
+		case in := <-fontIRQ:
+			func() {
+				defer close(in.reply)
+
+				if v, ok := parsedTTF[in.id]; ok {
+					in.reply <- v
+					return
+				}
+
+				f, err := truetype.Parse(in.data)
+				if err != nil {
+					in.reply <- err
+					return
+				}
+
+				parsedTTF[in.id] = f
+				in.reply <- f
+			}()
+		}
+	}
+}
+func makefont(data []byte, size int) *Font {
+	if fontIRQ == nil{
+		fontIRQ = make(chan fontPKT)
+		go fontsrv()
+	}
+	reply := make(chan interface{})
+	fontIRQ <- fontPKT{
+		id:    string(crc32.NewIEEE().Sum(data)),
+		reply: reply,
+		data:  data,
+	}
+	rx := <-reply
+	switch rx := rx.(type) {
+	case error:
+		println(rx)
+		return nil
+	case *truetype.Font:
+		return &Font{
+			Face: truetype.NewFace(rx,
+				&truetype.Options{
+					Size: float64(size),
+				}),
+			size:     size,
+			ascent:   2,
+			descent:  +(size / 3),
+			stride:   0,
+			data:     data,
+			imgCache: make(map[signature]*image.RGBA),
+		}
+	}
+	panic("makefont")
+}


### PR DESCRIPTION
This change adds a cache for already-seen glyphs. The changes affect mainly the font subpackage. 

There is no package API breakage in this change. Although it may cause issues in situations where the selected font is meant to be "transparent". This was not considered is because that feature doesn't work anyway.

There is a plan to make this change conditional, only occuring with foreground colors that have opaque alpha channels.

The change works by inserting a cache into frame/font.StringBG. On each call to StringBG, StringBG checks to see if a glyph from a font face has already been printed. If it has, it accesses an opaque image of the font with that certain background color from its cache and performs a src draw.Draw instead of a draw.Over with the font mask.

Some other housekeeping changes apply to other files, along with some new function that are not used at this time (deconvolution of small/blurry fonts).